### PR TITLE
Introduce getter for queue length

### DIFF
--- a/lib/src/semaphore/semaphore.dart
+++ b/lib/src/semaphore/semaphore.dart
@@ -66,4 +66,7 @@ abstract class Semaphore {
       completer.complete();
     }
   }
+
+  /// Get the count of running acquire calls that did not release yet.
+  int get queueLength => _currentCount;
 }


### PR DESCRIPTION
Hi,
thanks for your work! I'd like to add a feature:  
In some cases it is good to know how many functions want to use a semaphore.